### PR TITLE
Added redux reducer API for plugins

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -19,6 +19,8 @@ rules:
   import/no-dynamic-require: 0
   import/no-extraneous-dependencies: 1
   import/extensions: 1
+  import/prefer-default-export: 1
+  import/no-mutable-exports: 1
   indent:
     - 1
     - 2

--- a/src/components/module.jsx
+++ b/src/components/module.jsx
@@ -34,7 +34,7 @@ export default class Module extends Component {
     if (pluginJSON.tara.hasOwnProperty("client")) {
       this.setState({ contents: require(join(plugin_location, pluginJSON.tara.client)).default });
     } else {
-      this.setState({ contents: require(join(plugin_location, pluginJSON.main)).default });
+      this.setState({ contents: require(join(plugin_location, pluginJSON.main)).client });
     }
   }
   render() {

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -21,6 +21,11 @@
     <!-- Bootstrap -->
     <!--<script async src="../../node_modules/bootstrap/dist/js/bootstrap.min.js" charset="utf-8"></script>-->
     <!-- Our stuff -->
+    <script type="text/javascript">
+      // Put tara into the global namespace
+      global.tara = require("../renderer/boot/plugin-init").default;
+    </script>
+    <!-- And now load tara UI -->
     <script async src="../index.jsx" charset="utf-8"></script>
   </body>
 </html>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,7 @@ import ReactDOM from "react-dom";
 import { AppContainer } from "react-hot-loader";
 import { Provider } from "react-redux";
 import { createStore } from "redux";
-import reducers from "../reducers"; // eslint-disable-line
+import reducers from "../reducers";
 
 // Add global tara object
 import Tara from "../renderer/boot/plugin-init"; // eslint-disable-line

--- a/src/packages/tara-address-bar/components/index.jsx
+++ b/src/packages/tara-address-bar/components/index.jsx
@@ -6,27 +6,13 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 
 export default class TaraAddressBar extends Component {
-  constructor() {
-    super();
-    this.state = {
-      dir: "Waiting for dir...."
-    };
-  }
-  componentDidMount() {
-    // Get current dir
-    global.tara.getPlugin("tara-explorer")
-      .then(api => global.tara.addEventListener("explorer", api.constants.EXPLORER_SEND_DIR, (event, data) => {
-        console.log(data);
-      }));
-  }
-
   render() {
     return (
-      <p>{this.state.dir}</p>
+      <p>{this.props.dir.dir}</p>
     );
   }
 }
 
 TaraAddressBar.propTypes = {
-  tara: PropTypes.object.isRequired
+  dir: PropTypes.object.isRequired
 };

--- a/src/packages/tara-address-bar/containers/index.jsx
+++ b/src/packages/tara-address-bar/containers/index.jsx
@@ -1,0 +1,14 @@
+/**
+ * @overview Container of address bar
+ */
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import AddressBar from "../components/index";
+
+const mapStateToProps = (state) => {
+  return state;
+};
+
+const App = connect(mapStateToProps)(AddressBar);
+
+export default connect(mapStateToProps)(AddressBar);

--- a/src/packages/tara-address-bar/index.js
+++ b/src/packages/tara-address-bar/index.js
@@ -1,9 +1,5 @@
-// Sample plugin
-// Should contain 3 props:
-//  init: function to export layout for plugin
-//  client: property containing react jsx
-//  main: main process function to run on startup
-// Can be written in ES6
+import { App } from "./containers";
+
 const init = async (tara, done) => {
   // Get a panel
   tara.getPanelByName("explorer")
@@ -22,7 +18,10 @@ const main = (tara) => {
   // server.start();
 };
 
+const client = App;
+
 module.exports = {
   main,
-  init
+  init,
+  client
 };

--- a/src/packages/tara-address-bar/package.json
+++ b/src/packages/tara-address-bar/package.json
@@ -3,10 +3,11 @@
   "main": "index.js",
   "tara": {
     "type": "plugin",
-    "client": "components/index.jsx"
+    "client": "containers/index.jsx"
   },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react": "^15.5.4"
+    "react": "^15.5.4",
+    "react-redux": "^5.0.5"
   }
 }

--- a/src/packages/tara-address-bar/yarn.lock
+++ b/src/packages/tara-address-bar/yarn.lock
@@ -10,6 +10,14 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
+create-react-class@^15.5.3:
+  version "15.5.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.5.3.tgz#fb0f7cae79339e9a179e194ef466efa3923820fe"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
@@ -28,9 +36,19 @@ fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+hoist-non-react-statics@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
 iconv-lite@~0.4.13:
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
+
+invariant@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  dependencies:
+    loose-envify "^1.0.0"
 
 is-stream@^1.0.1:
   version "1.1.0"
@@ -47,6 +65,14 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
+lodash-es@^4.2.0:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
+
+lodash@^4.2.0:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
@@ -60,7 +86,7 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-object-assign@^4.1.0:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -76,6 +102,18 @@ prop-types@^15.5.10, prop-types@^15.5.7:
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
+
+react-redux@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.5.tgz#f8e8c7b239422576e52d6b7db06439469be9846a"
+  dependencies:
+    create-react-class "^15.5.3"
+    hoist-non-react-statics "^1.0.3"
+    invariant "^2.0.0"
+    lodash "^4.2.0"
+    lodash-es "^4.2.0"
+    loose-envify "^1.1.0"
+    prop-types "^15.5.10"
 
 react@^15.5.4:
   version "15.5.4"

--- a/src/packages/tara-explorer/actions/index.js
+++ b/src/packages/tara-explorer/actions/index.js
@@ -1,0 +1,21 @@
+/**
+ * @overview Index of actions
+ */
+import { TARA_UPDATE_DIR } from "../constants";
+
+/**
+ * Updates dir
+ * @param {String} dir Dir to update to
+ * @returns {Object} Action for reducer
+ */
+export const updateDir = (dir) => {
+  return {
+    type: TARA_UPDATE_DIR,
+    dir
+  };
+};
+
+// Put them all together and export
+export default {
+  updateDir
+};

--- a/src/packages/tara-explorer/components/index.jsx
+++ b/src/packages/tara-explorer/components/index.jsx
@@ -7,7 +7,7 @@ import { HashRouter as Router, Route, Redirect, Switch } from "react-router-dom"
 import { Provider } from "react-redux";
 import PropTypes from "prop-types";
 import { DefaultPage, HomeDir } from "./pages";
-import ShowDir from "./show-dir";
+import ShowDir from "../containers/show-dir";
 
 // Export
 export default class Explorer extends Component {

--- a/src/packages/tara-explorer/components/pages/home-dir.jsx
+++ b/src/packages/tara-explorer/components/pages/home-dir.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component } from "react";
 import { homedir } from "os";
-import Dir from "../show-dir";
+import Dir from "../../containers/show-dir";
 
 export default class HomeDir extends Component {
   render() {

--- a/src/packages/tara-explorer/components/show-dir.jsx
+++ b/src/packages/tara-explorer/components/show-dir.jsx
@@ -11,6 +11,7 @@ import { readdir, statSync } from "fs";
 import { Grid } from "semantic-ui-react";
 import FontAwesome from "react-fontawesome";
 import { Redirect } from "react-router-dom";
+import { updateDir as chdir } from "../actions";
 
 // NOTE: From https://stackoverflow.com/questions/1828613/check-if-a-key-is-down
 const keys = {};
@@ -66,10 +67,13 @@ export default class Dir extends Component {
         });
         // Send dir message
         global.tara.getPlugin("tara-explorer")
-          .then(api => global.tara.send("explorer", api.constants.EXPLORER_SEND_DIR, this.state.dir));
+          .then(api => global.tara.send("explorer", api.constants.EXPLORER_SEND_DIR, this.props.dir.dir));
         // Check for double click
         for (let file of this.state.contents) {
-          jquery(`#${camelcase(file)}`).dblclick(() => this.getFiles(`${join(this.state.dir, file)}`));
+          jquery(`#${camelcase(file)}`).dblclick(() => {
+            this.getFiles(`${join(this.props.dir.dir, file)}`);
+            this.props.dispatch(chdir(join(this.props.dir.dir, file)));
+          });
         }
       }
     });
@@ -102,7 +106,7 @@ export default class Dir extends Component {
         <Grid.Row>
           <Grid.Column size={2}>
             {
-              this.state.contents.map(file => (statSync(join(this.state.dir, file)).isDirectory() ? // Check if path is dir
+              this.state.contents.map(file => (statSync(join(this.props.dir.dir, file)).isDirectory() ? // Check if path is dir
                 <div id={camelcase(file)} role="presentation" className="file-wrapper" onClick={this.handleOnClick(camelcase(file))}>
                   <FontAwesome name="folder" />
                   <p>{getFileName(file)}</p>
@@ -110,7 +114,7 @@ export default class Dir extends Component {
               : null))
             }
             {
-              this.state.contents.map(file => (!statSync(join(this.state.dir, file)).isDirectory() ? // Check if path is file
+              this.state.contents.map(file => (!statSync(join(this.props.dir.dir, file)).isDirectory() ? // Check if path is file
                 <div id={camelcase(file)} role="presentation" className="file-wrapper" onClick={this.handleOnClick(camelcase(file))}>
                   <FontAwesome name="file" />
                   <p>{getFileName(file)}</p>
@@ -127,5 +131,7 @@ export default class Dir extends Component {
 }
 
 Dir.propTypes = {
-  match: PropTypes.object.isRequired
+  match: PropTypes.object.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  dir: PropTypes.object.isRequired
 };

--- a/src/packages/tara-explorer/containers/show-dir.jsx
+++ b/src/packages/tara-explorer/containers/show-dir.jsx
@@ -1,0 +1,11 @@
+/**
+ * @overview Container for showd-dir component
+ */
+import { connect } from "react-redux";
+import ShowDir from "../components/show-dir";
+
+const mapStateToProps = (state) => {
+  return state;
+};
+
+export default connect(mapStateToProps)(ShowDir);

--- a/src/packages/tara-explorer/index.js
+++ b/src/packages/tara-explorer/index.js
@@ -2,6 +2,7 @@
  * @overview Tara's explorer entry point
  * @module tara/explorer
  */
+import actions from "./actions";
 import constants from "./constants";
 
 const api = {
@@ -10,7 +11,8 @@ const api = {
 
 const main = (tara) => {
   tara.addApi("explorer", {
-    constants
+    constants,
+    actions
   });
   tara.logger.info("Explorer started.");
 };

--- a/src/packages/tara-explorer/package.json
+++ b/src/packages/tara-explorer/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/Gum-Joe/tara#readme",
   "tara": {
     "type": "plugin",
-    "client": "components/index.jsx"
+    "client": "components/index.jsx",
+    "reducers": "reducers/index.js"
   },
   "dependencies": {
     "camelcase": "^4.1.0",

--- a/src/packages/tara-explorer/reducers/defaults.js
+++ b/src/packages/tara-explorer/reducers/defaults.js
@@ -1,0 +1,8 @@
+/**
+ * @overview Default states
+ */
+import { homedir } from "os";
+
+export const dir = {
+  dir: homedir()
+};

--- a/src/packages/tara-explorer/reducers/dir.js
+++ b/src/packages/tara-explorer/reducers/dir.js
@@ -1,0 +1,31 @@
+/**
+ * @overview Dir reducer.  Stores dir as dir: {string}
+ */
+import { TARA_UPDATE_DIR } from "../constants";
+import { dir as defaultState } from "./defaults";
+
+/**
+ * Dir reducer.
+ * Actions:
+ *  TARA_UPDATE_DIR: Updates dir (like chdir)
+ * Action format:
+ *  {
+ *    type: {string} action type (listed above)
+ *    dir: {string} new dir
+ *  }
+ * @param {Object} state Redux state
+ * @param {Object} action Action object
+ */
+
+export default (state = defaultState, action) => {
+  switch (action.type) {
+  case TARA_UPDATE_DIR:
+    return {
+      ...state,
+      dir: action.dir
+    };
+    break;
+  default:
+    return state;
+  }
+};

--- a/src/packages/tara-explorer/reducers/index.js
+++ b/src/packages/tara-explorer/reducers/index.js
@@ -1,23 +1,9 @@
 /**
  * @overview Index of reducers & redux store maker
  */
-import { createStore, combineReducers, applyMiddleware } from "redux";
-import createHistory from "history/createMemoryHistory";
-import { routerReducer, routerMiddleware } from "react-router-redux";
-// Our reducers
-import router from "./router";
+import dir from "./dir";
 
-// Create a history of your choosing (we're using a browser history in this case)
-const history = createHistory();
-
-// Build the middleware for intercepting and dispatching navigation actions
-const middleware = routerMiddleware(history);
-
-// Combine & export
-// Also apply our middleware for navigating
-const store = createStore(
-  combineReducers({
-    router: routerReducer
-  }),
-  applyMiddleware(middleware)
-);
+// Export
+export default {
+  dir
+};

--- a/src/packages/tara-explorer/reducers/router.js
+++ b/src/packages/tara-explorer/reducers/router.js
@@ -1,7 +1,0 @@
-/**
- * @overview Reducer for router
- */
-
-export default (state, route) => {
-  console.log(route);
-};

--- a/src/reducers/get-plugin-reducers.js
+++ b/src/reducers/get-plugin-reducers.js
@@ -1,0 +1,48 @@
+/**
+ * @overview File to get redux reducers from file
+ */
+import { join } from "path";
+import { PLUGIN_CONFIG, PLUGIN_LOCATION, PLUGIN_CORE_CONFIG, PLUGIN_CORE_LOCATION } from "../renderer/constants";
+import { getPluginPath } from "../renderer/utils";
+import getPlugins from "../renderer/boot/plugins";
+
+/**
+ * Gets reducers from plugins, by looking for the export file,
+ * either main.js/reducers
+ * or reducers.js.  Reducer files should export an object of reducer (i.e. reducerName: reducer()), actions should be in api.actions
+ * @returns {Promise} Reducers to use in combineReducers()
+ * @function getReducers
+ */
+export default () => {
+  // Get plugin list
+  const plugins = [
+    ...getPlugins(PLUGIN_CONFIG, PLUGIN_LOCATION),
+    ...getPlugins(PLUGIN_CORE_CONFIG, PLUGIN_CORE_LOCATION)
+  ];
+  let reducersObj = {};
+  for (let plugin of plugins) {
+    const location = getPluginPath(plugin.name);
+    const pkgJSON = require(join(location, "package.json"));
+    // Check where to get reducer from
+    if (pkgJSON.hasOwnProperty("tara") && pkgJSON.tara.hasOwnProperty("reducers") && pkgJSON.tara.type === "plugin") {
+      // Rqeuire reducer file
+      const reducers = require(join(location, pkgJSON.tara.reducers)).default;
+      reducersObj = {
+        ...reducersObj,
+        ...reducers
+      };
+    } else if (pkgJSON.tara.type === "plugin") {
+      // Require main file
+      const { reducers } = require(join(location, pkgJSON.main));
+      reducersObj = {
+        ...reducersObj,
+        ...reducers
+      };
+    }
+
+    // If this is the last plugin, resolve
+    if (plugins[plugins.length - 1] === plugin) {
+      return reducersObj;
+    }
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,10 +3,14 @@
  * Combines reducers and exports
  */
 import { combineReducers } from "redux";
-import layout from "./layout";
-import plugins from "./plugins";
+import layout from "../reducers/layout";
+import getReducers from "../reducers/get-plugin-reducers";
+import plugins from "../reducers/plugins";
 
+// Get reducers from plugins & combine with our reducers
+const reducers = getReducers();
 const rootReducer = combineReducers({
+  ...reducers,
   layout,
   plugins
 });

--- a/src/renderer/boot/event-listeners.js
+++ b/src/renderer/boot/event-listeners.js
@@ -2,18 +2,35 @@
  * @overview Listens for events for tara
  */
 import { cyan, yellow } from "chalk";
-import { ipcMain as ipc } from "electron"; // eslint-disable-line
+import electron from "electron"; // eslint-disable-line
+import * as listeners from "./ipc";
 import Logger from "../logger";
+import TaraPlugin from "./plugin-init";
 
 const logger = new Logger({
   name: "ipc"
 });
 
 /**
- * Adds event listerners
+ * Adds event listeners
  * @function addEventListeners
  * @returns {undefined} Nothing
  */
 export default () => {
-  logger.debug("Nothing to do here.");
+  logger.debug("Adding event listeners...");
+  logger.debug("Creating array...");
+  let arrayOfListeners = [];
+  for (let listenerParent in listeners) {
+    // Loop through a module of listeners
+    for (let listener in listeners[listenerParent]) {
+      if (listeners[listenerParent].hasOwnProperty(listener)) {
+        // ... and execute it
+        logger.debug(`Starting listener ${yellow(listener)} from ${cyan(listenerParent)}...`);
+        const tara = new TaraPlugin({
+          name: "ipc"
+        }, electron, logger);
+        listeners[listenerParent][listener](tara);
+      }
+    }
+  }
 };

--- a/src/renderer/boot/ipc/index.js
+++ b/src/renderer/boot/ipc/index.js
@@ -1,0 +1,4 @@
+/**
+ * @overview Index of ipc listerners
+ */
+export * as plugins from "./plugins";

--- a/src/renderer/boot/ipc/plugins.js
+++ b/src/renderer/boot/ipc/plugins.js
@@ -1,0 +1,20 @@
+/**
+ * @overview Plugins event listeners
+ */
+import { IPC_GET_PLUGINS, IPC_SEND_PLUGINS, PLUGIN_CONFIG, PLUGIN_LOCATION, PLUGIN_CORE_CONFIG, PLUGIN_CORE_LOCATION } from "../../constants";
+import getPlugins from "../plugins";
+
+/**
+ * Plugin event listener to send plugins.  Takes constants.IPC_GET_PLUGINS for receiving & sends back constants.IPC_SEND_PLUGINS
+ * @param {TaraPlugin} tara class to use for plugin events
+ * @returns {undefined} Nothing
+ */
+export function sendPlugins(tara) {
+  tara.addEventListener("core", IPC_GET_PLUGINS, (event, data) => {
+    tara.logger.debug("Plugins requested. Sending...");
+    event.sender.send(`core::${IPC_SEND_PLUGINS}`, [
+      ...getPlugins(PLUGIN_CONFIG, PLUGIN_LOCATION),
+      ...getPlugins(PLUGIN_CORE_CONFIG, PLUGIN_CORE_LOCATION)
+    ]);
+  });
+}

--- a/src/renderer/boot/plugin-init.js
+++ b/src/renderer/boot/plugin-init.js
@@ -11,15 +11,20 @@ import { PLUGIN_LOCATION, PLUGIN_CORE_LOCATION, PLUGIN_CONFIG, PLUGIN_CORE_CONFI
  * @class TaraPlugin
  * @param {Object} plugin Plugin that the class is bewing used for
  * @param {Object} electron Electron
+ * @param {Logger} logger (optional) Logger to use
  */
 export default class TaraPlugin {
-  constructor(plugin, electron) {
+  constructor(plugin, electron, logger) {
     this.plugin = plugin;
-    this.logger = new Logger({
+    this.logger = logger || new Logger({
       name: `plugin:${this.plugin.name}`
     });
     // Electron to use
     this.electron = electron;
+    // Bind static methods to this
+    this.addEventListener = TaraPlugin.addEventListener.bind(this);
+    this.send = TaraPlugin.send.bind(this);
+    this.getPlugin = TaraPlugin.getPlugin.bind(this);
   }
 
   /**
@@ -58,7 +63,7 @@ export default class TaraPlugin {
    * @returns {undefined} Nothing
    * @static
    */
-  static send(module, channel, data) {
+  static send(module, channel, data = "") {
     if (typeof window === "undefined") {
       const ipc = require("electron").ipcMain; // eslint-disable-line
       ipc.send(`${module}::${channel}`, data);

--- a/src/renderer/constants.js
+++ b/src/renderer/constants.js
@@ -24,6 +24,8 @@ export const REGEN_LAYOUT_ARGS = "--regen-layout";
 // IPC stuff
 export const GET_PLUGIN_CLIENT = "GET_PLUGIN_CLIENT";
 export const SEND_PLUGIN_CLIENT = "SEND_PLUGIN_CLIENT";
+export const IPC_GET_PLUGINS = "IPC_GET_PLUGINS";
+export const IPC_SEND_PLUGINS = "IPC_SEND_PLUGINS";
 // Theme stuff
 export const THEME_FILE_CONTENTS_DEFAULT = `// Theme file for tara
 // Contains theme name & import for theme file

--- a/src/renderer/utils/index.js
+++ b/src/renderer/utils/index.js
@@ -3,3 +3,4 @@
  * @module utils
  */
 export copy from "./copy";
+export getPluginPath from "./get-plugin-path";


### PR DESCRIPTION
This PR allows plugins to add their own reducers to the redux store. 
## How it works:

- Plugins should export either:
  - a `reducers` prop from the main script
  - specify a `reducers` file in the `tara` object in the package.json
- For actions:
  - Specify them in the API register under the `actions` prop

#### Issues needing to be fixed:
- #5: Dir reducer will change, but Explorer thinks it is showing a different dir

## Commit Log
a5a0596
:lipstick: Added address bar
:shirt: Fix some issues with eslint
:ambulance: Fix an issue where wrong prop was required when handleing main.client for plugins
:art: Put class TaraPlugin into global namespace
:art: Setup redux reducer api for plugins
:art: Added reducer for storeing dir
:bug: NOTE: explorer still can only go one level deep (#5)
:art: Added explorer chdir for reducer
:art: Bind static methods to inited class (TaraPlugin)